### PR TITLE
feat: change search to regex

### DIFF
--- a/src/repositories/MangaRepository.ts
+++ b/src/repositories/MangaRepository.ts
@@ -51,15 +51,12 @@ class MangaRepository implements IMangaRepository {
       page: data.page,
       limit: this.mangasPerPage,
       projection: { chapters: 0 },
-      sort: { score: { $meta: "textScore" } },
     };
-
-    const term = `\"${data.searchTerm}\"`;
 
     const results = await this.MangaModel.paginate(
       {
         origin: data.origin,
-        $text: { $search: term },
+        title: { $regex: data.searchTerm, $options: "i" },
       },
       options
     );


### PR DESCRIPTION
Alteração na forma de busca da API. Ao invés de buscar documentos via busca de índice textual, utiliza regex afim de encontrar substrings no título.